### PR TITLE
shellcheck + updates

### DIFF
--- a/flake.lock
+++ b/flake.lock
@@ -2,11 +2,11 @@
   "nodes": {
     "flake-utils": {
       "locked": {
-        "lastModified": 1623875721,
-        "narHash": "sha256-A8BU7bjS5GirpAUv4QA+QnJ4CceLHkcXdRp4xITDB0s=",
+        "lastModified": 1649676176,
+        "narHash": "sha256-OWKJratjt2RW151VUlJPRALb7OU2S5s+f0vLj4o1bHM=",
         "owner": "numtide",
         "repo": "flake-utils",
-        "rev": "f7e004a55b120c02ecb6219596820fcd32ca8772",
+        "rev": "a4b154ebbdc88c8498a5c7b01589addc9e9cb678",
         "type": "github"
       },
       "original": {
@@ -17,17 +17,17 @@
     },
     "nixpkgs": {
       "locked": {
-        "lastModified": 1625442144,
-        "narHash": "sha256-uv+nt5iaqZ5By/uxeCaNdaaFkwRqj+4JoAt0VTGPFMo=",
+        "lastModified": 1649986882,
+        "narHash": "sha256-cNsInUFq1MbuvaEmv8x6jetWnmAU+osMpnwKumtjksI=",
         "owner": "NixOS",
         "repo": "nixpkgs",
-        "rev": "7229e6d646c90d2097099a825371601f1e8ad381",
+        "rev": "5181d5945eda382ff6a9ca3e072ed6ea9b547fee",
         "type": "github"
       },
       "original": {
-        "owner": "NixOS",
-        "repo": "nixpkgs",
-        "type": "github"
+        "id": "nixpkgs",
+        "ref": "nixos-unstable",
+        "type": "indirect"
       }
     },
     "root": {

--- a/flake.nix
+++ b/flake.nix
@@ -2,25 +2,46 @@
   description = "Shell script collection to download ELF binaries and use them right away!";
 
   inputs = {
-    nixpkgs.url = "github:NixOS/nixpkgs";
+    nixpkgs.url = "nixpkgs/nixos-unstable";
     flake-utils.url = "github:numtide/flake-utils";
   };
 
-  outputs = { self, nixpkgs, flake-utils }:
+  outputs = { self, nixpkgs, flake-utils }: let
+      l = nixpkgs.lib // builtins;
+
+      scriptNames =
+        l.filter
+        (script: l.hasPrefix "nix-autobahn" script)
+        (l.attrNames (l.readDir ./.));
+  in
     flake-utils.lib.eachDefaultSystem (system:
       let
         pkgs = nixpkgs.legacyPackages.${system};
         packageName = "nix-autobahn";
+
+        scripts =
+          l.map
+            (scriptName:
+              pkgs.writeShellApplication {
+                name = scriptName;
+                text = l.readFile ("${./.}/${scriptName}");
+
+                runtimeInputs = with pkgs; [
+                  findutils
+                  fzf
+                  nix-index
+                  nix-ld
+                ];
+              })
+            scriptNames;
       in {
-        packages.${packageName} = pkgs.stdenv.mkDerivation {
-          name = packageName;
-          src = ./.;
-          installPhase = ''
-            echo nix-autobahn*
-            mkdir -p $out/bin
-            mv nix-autobahn* $out/bin
-          '';
-        };
+
+        packages.${packageName} = pkgs.runCommand "nix-autobahn" {} ''
+          mkdir -p $out/bin
+          for script in ${l.toString scripts}; do
+            cp $script/bin/* $out/bin/
+          done
+        '';
 
         defaultPackage = self.packages.${system}.${packageName};
       });

--- a/nix-autobahn-fhs-shell
+++ b/nix-autobahn-fhs-shell
@@ -1,5 +1,5 @@
 #!/bin/sh
-PACKAGES="$@"
+PACKAGES="$*"
 SCRIPT=${SCRIPT:-bash}
 
 FHS=$(cat << EOF | bash

--- a/nix-autobahn-find-libs
+++ b/nix-autobahn-find-libs
@@ -1,4 +1,6 @@
 #!/bin/sh
+
+# shellcheck disable=SC2001
 LIBS_NOT_FOUND=$(ldd "$1" | grep 'not found' | sed 's/ .*//;s/\t//' | sort | uniq)
 SELECTED_LIBS=""
 
@@ -26,6 +28,7 @@ for x in $LIBS_NOT_FOUND; do
     SELECTED_LIBS="$SELECTED_LIBS $(echo "$candidates" | fzf --ansi | sed 's/ .*//')"
     # If only one option viable choose it automatically
   else
+    # shellcheck disable=SC2001
     SELECTED_LIBS="$SELECTED_LIBS $(echo "$candidates" | sed 's/ .*//')"
   fi
 done

--- a/nix-autobahn-ld
+++ b/nix-autobahn-ld
@@ -3,7 +3,8 @@
 set -x
 export SCRIPT
 SCRIPT=$(realpath "$1")
-export BASESCRIPT=$(basename "$SCRIPT")
+BASESCRIPT=$(basename "$SCRIPT")
+export BASESCRIPT
 
 SCRIPTDIR=$(dirname "$0")
 

--- a/nix-autobahn-ld-shell
+++ b/nix-autobahn-ld-shell
@@ -1,5 +1,5 @@
 #!/bin/sh
-PACKAGES="$@"
+PACKAGES="$*"
 
 mkdir -p ~/.cache/nix-autobahn
 


### PR DESCRIPTION
Done:
- update flake inputs
- use pkgs.writeShellApplication, and add runtime deps as inputs
- fix shelcheck errors

I'm actually looking for a fully automated approach for finding dependencies.
Nix-autobahn still requires user interaction.
One solution might be to add a flag `--non-interactive`.
But before I do this, I'll have a look at nix-alien. It's written in python and therefore might be better suited for being extended.